### PR TITLE
Fix: Update cover path

### DIFF
--- a/Center Taskbar/Playerinfo+PlayerVisulizer.ini
+++ b/Center Taskbar/Playerinfo+PlayerVisulizer.ini
@@ -50,7 +50,7 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-CoverPath = "#@#Cover.png"
+Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Center Taskbar/Playerinfo+PlayerVisulizer.ini
+++ b/Center Taskbar/Playerinfo+PlayerVisulizer.ini
@@ -50,7 +50,6 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Center Taskbar/Weather+PlayerInfo.ini
+++ b/Center Taskbar/Weather+PlayerInfo.ini
@@ -49,7 +49,6 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Center Taskbar/Weather+PlayerInfo.ini
+++ b/Center Taskbar/Weather+PlayerInfo.ini
@@ -49,7 +49,7 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-CoverPath = "#@#Cover.png"
+Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Center Taskbar/Weather+PlayerVisulizer.ini
+++ b/Center Taskbar/Weather+PlayerVisulizer.ini
@@ -50,7 +50,7 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-CoverPath = "#@#Cover.png"
+Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Center Taskbar/Weather+PlayerVisulizer.ini
+++ b/Center Taskbar/Weather+PlayerVisulizer.ini
@@ -50,7 +50,6 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Left Taskbar/Playerinfo+PlayerVisulizer.ini
+++ b/Left Taskbar/Playerinfo+PlayerVisulizer.ini
@@ -50,7 +50,7 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-CoverPath = "#@#Cover.png"
+Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape

--- a/Left Taskbar/Playerinfo+PlayerVisulizer.ini
+++ b/Left Taskbar/Playerinfo+PlayerVisulizer.ini
@@ -50,7 +50,6 @@ Measure = Plugin
 Plugin = WebNowPlaying
 PlayerType = Cover
 DefaultPath = "#@#Default.png"
-Cover = "#@#Cover.png"
 
 [MeterCoverContainer]
 Meter = Shape


### PR DESCRIPTION
Hey there, I started using this skin and noticed the album image never got updated. It always showed the default image.
<img width="225" height="46" alt="image" src="https://github.com/user-attachments/assets/711ee060-bca1-4c96-8fde-14bfd96072c2" />

Looking at the docs I noticed `CoverPath` is an outdated way of showing the cover. 
~I updated the skin to use the `Cover` option mentioned in the docs: https://wnp.keifufu.dev/rainmeter/usage~
Removing this option fixes the issue as `PlayerType = Cover` already captures the image.

Result:
<img width="220" height="48" alt="image" src="https://github.com/user-attachments/assets/3be27cb6-697e-4c3e-b606-677ff1d783f6" />
